### PR TITLE
Show the prompt on the basis of an event count

### DIFF
--- a/AppRater/src/main/java/org/codechimp/apprater/AppRater.java
+++ b/AppRater/src/main/java/org/codechimp/apprater/AppRater.java
@@ -14,296 +14,333 @@ import android.util.Log;
 import android.widget.Toast;
 
 public class AppRater {
-    // Preference Constants
-    private final static String PREF_NAME = "apprater";
-    private final static String PREF_LAUNCH_COUNT = "launch_count";
-    private final static String PREF_FIRST_LAUNCHED = "date_firstlaunch";
-    private final static String PREF_DONT_SHOW_AGAIN = "dontshowagain";
-    private final static String PREF_REMIND_LATER = "remindmelater";
-    private final static String PREF_APP_VERSION_NAME = "app_version_name";
-    private final static String PREF_APP_VERSION_CODE = "app_version_code";
+	// Preference Constants
+	private final static String PREF_NAME = "apprater";
+	private final static String PREF_LAUNCH_COUNT = "launch_count";
+	private final static String PREF_EVENT_COUNT = "event_count";
+	private final static String PREF_FIRST_LAUNCHED = "date_firstlaunch";
+	private final static String PREF_DONT_SHOW_AGAIN = "dontshowagain";
+	private final static String PREF_REMIND_LATER = "remindmelater";
+	private final static String PREF_APP_VERSION_NAME = "app_version_name";
+	private final static String PREF_APP_VERSION_CODE = "app_version_code";
 
-    private final static int DAYS_UNTIL_PROMPT = 3;
-    private final static int LAUNCHES_UNTIL_PROMPT = 7;
-    private static int DAYS_UNTIL_PROMPT_FOR_REMIND_LATER = 3;
-    private static int LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER = 7;
-    private static boolean isDark;
-    private static boolean themeSet;
-    private static boolean hideNoButton;
-    private static boolean isVersionNameCheckEnabled;
-    private static boolean isVersionCodeCheckEnabled;
+	private final static int DAYS_UNTIL_PROMPT = 3;
+	private final static int LAUNCHES_UNTIL_PROMPT = 7;
+	private final static int EVENTS_UNTILL_PROMPT = 5;
+	private static int DAYS_UNTIL_PROMPT_FOR_REMIND_LATER = 3;
+	private static int LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER = 7;
+	private static boolean isDark;
+	private static boolean themeSet;
+	private static boolean hideNoButton;
+	private static boolean isVersionNameCheckEnabled;
+	private static boolean isVersionCodeCheckEnabled;
 
-    private static Market market = new GoogleMarket();
+	private static Market market = new GoogleMarket();
 
-    /**
-     * Decides if the version name check is active or not
-     *
-     * @param versionNameCheck
-     */
-    public static void setVersionNameCheckEnabled(boolean versionNameCheck) {
-        isVersionNameCheckEnabled = versionNameCheck;
-    }
+	/**
+	 * Decides if the version name check is active or not
+	 * 
+	 * @param versionNameCheck
+	 */
+	public static void setVersionNameCheckEnabled(boolean versionNameCheck) {
+		isVersionNameCheckEnabled = versionNameCheck;
+	}
 
-    /**
-     * Decides if the version code check is active or not
-     *
-     * @param versionCodeCheck
-     */
-    public static void setVersionCodeCheckEnabled(boolean versionCodeCheck) {
-        isVersionCodeCheckEnabled = versionCodeCheck;
-    }
+	/**
+	 * Decides if the version code check is active or not
+	 * 
+	 * @param versionCodeCheck
+	 */
+	public static void setVersionCodeCheckEnabled(boolean versionCodeCheck) {
+		isVersionCodeCheckEnabled = versionCodeCheck;
+	}
 
-    /**
-     * sets number of day until rating dialog pops up for next time when remind
-     * me later option is chosen
-     *
-     * @param daysUntilPromt
-     */
-    public static void setNumDaysForRemindLater(int daysUntilPromt) {
-        DAYS_UNTIL_PROMPT_FOR_REMIND_LATER = daysUntilPromt;
-    }
+	/**
+	 * sets number of day until rating dialog pops up for next time when remind
+	 * me later option is chosen
+	 * 
+	 * @param daysUntilPromt
+	 */
+	public static void setNumDaysForRemindLater(int daysUntilPromt) {
+		DAYS_UNTIL_PROMPT_FOR_REMIND_LATER = daysUntilPromt;
+	}
 
-    /**
-     * sets the number of launches until the rating dialog pops up for next time
-     * when remind me later option is chosen
-     *
-     * @param launchesUntilPrompt
-     */
-    public static void setNumLaunchesForRemindLater(int launchesUntilPrompt) {
+	/**
+	 * sets the number of launches until the rating dialog pops up for next time
+	 * when remind me later option is chosen
+	 * 
+	 * @param launchesUntilPrompt
+	 */
+	public static void setNumLaunchesForRemindLater(int launchesUntilPrompt) {
 
-        LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER = launchesUntilPrompt;
-    }
+		LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER = launchesUntilPrompt;
+	}
 
-    /**
-     * decides if No thanks button appear in dialog or not
-     *
-     * @param isNoButtonVisible
-     */
-    public static void setDontRemindButtonVisible(boolean isNoButtonVisible) {
-        AppRater.hideNoButton = isNoButtonVisible;
-    }
+	/**
+	 * decides if No thanks button appear in dialog or not
+	 * 
+	 * @param isNoButtonVisible
+	 */
+	public static void setDontRemindButtonVisible(boolean isNoButtonVisible) {
+		AppRater.hideNoButton = isNoButtonVisible;
+	}
 
-    /**
-     * Call this method at the end of your OnCreate method to determine whether
-     * to show the rate prompt using the specified or default day, launch count
-     * values and checking if the version is changed or not
-     *
-     * @param context
-     */
-    public static void app_launched(Context context) {
-        app_launched(context, DAYS_UNTIL_PROMPT, LAUNCHES_UNTIL_PROMPT);
-    }
+	/**
+	 * Call this method at the end of your OnCreate method to determine whether
+	 * to show the rate prompt using the specified or default day, launch count
+	 * values and checking if the version is changed or not
+	 * 
+	 * @param context
+	 */
+	public static void app_launched(Context context) {
+		app_launched(context, DAYS_UNTIL_PROMPT, LAUNCHES_UNTIL_PROMPT);
+	}
 
-    /**
-     * Call this method at the end of your OnCreate method to determine whether
-     * to show the rate prompt using the specified or default day, launch count
+	/**
+	 * Call this method at the end of your OnCreate method to determine whether
+	 * to show the rate prompt using the specified or default day, launch count
      * values with additional day and launch parameter for remind me later option
      * and checking if the version is changed or not
-     *
-     * @param context
-     * @param daysUntilPrompt
-     * @param launchesUntilPrompt
-     * @param daysForRemind
-     * @param launchesForRemind
-     */
+	 * 
+	 * @param context
+	 * @param daysUntilPrompt
+	 * @param launchesUntilPrompt
+	 * @param daysForRemind
+	 * @param launchesForRemind
+	 */
     public static void app_launched(Context context, int daysUntilPrompt, int launchesUntilPrompt, int daysForRemind, int launchesForRemind) {
-        setNumDaysForRemindLater(daysForRemind);
-        setNumLaunchesForRemindLater(launchesForRemind);
-        app_launched(context, daysUntilPrompt, launchesUntilPrompt);
-    }
+		setNumDaysForRemindLater(daysForRemind);
+		setNumLaunchesForRemindLater(launchesForRemind);
+		app_launched(context, daysUntilPrompt, launchesUntilPrompt);
+	}
 
-    /**
-     * Call this method at the end of your OnCreate method to determine whether
-     * to show the rate prompt
-     *
-     * @param context
-     * @param daysUntilPrompt
-     * @param launchesUntilPrompt
-     */
+	/**
+	 * Call this method at the end of your OnCreate method to determine whether
+	 * to show the rate prompt
+	 * 
+	 * @param context
+	 * @param daysUntilPrompt
+	 * @param launchesUntilPrompt
+	 */
     public static void app_launched(Context context, int daysUntilPrompt, int launchesUntilPrompt) {
         SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
+		SharedPreferences.Editor editor = prefs.edit();
         ApplicationRatingInfo ratingInfo = ApplicationRatingInfo.createApplicationInfo(context);
-        int days;
-        int launches;
-        if (isVersionNameCheckEnabled) {
+		int days;
+		int launches;
+		if (isVersionNameCheckEnabled) {
             if (!ratingInfo.getApplicationVersionName().equals(prefs.getString(PREF_APP_VERSION_NAME, "none"))) {
                 editor.putString(PREF_APP_VERSION_NAME, ratingInfo.getApplicationVersionName());
-                resetData(context);
-                commitOrApply(editor);
-            }
-        }
-        if (isVersionCodeCheckEnabled) {
+				resetData(context);
+				commitOrApply(editor);
+			}
+		}
+		if (isVersionCodeCheckEnabled) {
             if (ratingInfo.getApplicationVersionCode() != (prefs.getInt(PREF_APP_VERSION_CODE, -1))) {
                 editor.putInt(PREF_APP_VERSION_CODE, ratingInfo.getApplicationVersionCode());
-                resetData(context);
-                commitOrApply(editor);
-            }
-        }
-        if (prefs.getBoolean(PREF_DONT_SHOW_AGAIN, false)) {
-            return;
-        } else if (prefs.getBoolean(PREF_REMIND_LATER, false)) {
-            days = DAYS_UNTIL_PROMPT_FOR_REMIND_LATER;
-            launches = LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER;
-        } else {
-            days = daysUntilPrompt;
-            launches = launchesUntilPrompt;
-        }
+				resetData(context);
+				commitOrApply(editor);
+			}
+		}
+		if (prefs.getBoolean(PREF_DONT_SHOW_AGAIN, false)) {
+			return;
+		} else if (prefs.getBoolean(PREF_REMIND_LATER, false)) {
+			days = DAYS_UNTIL_PROMPT_FOR_REMIND_LATER;
+			launches = LAUNCHES_UNTIL_PROMPT_FOR_REMIND_LATER;
+		} else {
+			days = daysUntilPrompt;
+			launches = launchesUntilPrompt;
+		}
 
-        // Increment launch counter
-        long launch_count = prefs.getLong(PREF_LAUNCH_COUNT, 0) + 1;
-        editor.putLong(PREF_LAUNCH_COUNT, launch_count);
-        // Get date of first launch
-        Long date_firstLaunch = prefs.getLong(PREF_FIRST_LAUNCHED, 0);
-        if (date_firstLaunch == 0) {
-            date_firstLaunch = System.currentTimeMillis();
-            editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
-        }
-        // Wait for at least the number of launches or the number of days used
-        // until prompt
-        if (launch_count >= launches || (System.currentTimeMillis() >= date_firstLaunch + (days * 24 * 60 * 60 * 1000))) {
-            showRateAlertDialog(context, editor);
-        }
-        commitOrApply(editor);
-    }
+		// Increment launch counter
+		long launch_count = prefs.getLong(PREF_LAUNCH_COUNT, 0) + 1;
+		editor.putLong(PREF_LAUNCH_COUNT, launch_count);
+		// Get date of first launch
+		Long date_firstLaunch = prefs.getLong(PREF_FIRST_LAUNCHED, 0);
+		if (date_firstLaunch == 0) {
+			date_firstLaunch = System.currentTimeMillis();
+			editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
+		}
 
-    /**
-     * Call this method directly if you want to force a rate prompt, useful for
-     * testing purposes
-     *
-     * @param context
-     */
-    public static void showRateDialog(final Context context) {
-        showRateAlertDialog(context, null);
-    }
+		// Get Event counter
+		long event_count = prefs.getLong(PREF_EVENT_COUNT, 0);
 
-    /**
-     * Call this method directly to go straight to play store listing for rating
-     *
-     * @param context
-     */
-    public static void rateNow(final Context context) {
-        try {
+		// Wait for at least the number of launches or the number of days used
+		// until prompt
+		if (launch_count >= launches
+				|| (System.currentTimeMillis() >= date_firstLaunch
+						+ (days * 24 * 60 * 60 * 1000))
+				|| event_count > EVENTS_UNTILL_PROMPT) {
+			showRateAlertDialog(context, editor);
+		}
+		commitOrApply(editor);
+	}
+
+	/**
+	 * Call this method to increment event count.
+	 * 
+	 * @param context
+	 */
+	public static void incrementEventCount(final Context context) {
+		SharedPreferences prefs = context.getSharedPreferences(PREF_NAME,
+				Context.MODE_PRIVATE);
+		SharedPreferences.Editor editor = prefs.edit();
+		long event_count = prefs.getLong(PREF_LAUNCH_COUNT, 0) + 1;
+		editor.putLong(PREF_LAUNCH_COUNT, event_count);
+		commitOrApply(editor);
+	}
+
+	/**
+	 * Call this method to reset event count.
+	 * 
+	 * @param context
+	 */
+	public static void resetEventCount(final Context context) {
+		SharedPreferences prefs = context.getSharedPreferences(PREF_NAME,
+				Context.MODE_PRIVATE);
+		SharedPreferences.Editor editor = prefs.edit();
+		editor.putLong(PREF_LAUNCH_COUNT, 0);
+		commitOrApply(editor);
+	}
+
+	/**
+	 * Call this method directly if you want to force a rate prompt, useful for
+	 * testing purposes
+	 * 
+	 * @param context
+	 */
+	public static void showRateDialog(final Context context) {
+		showRateAlertDialog(context, null);
+	}
+
+	/**
+	 * Call this method directly to go straight to play store listing for rating
+	 * 
+	 * @param context
+	 */
+	public static void rateNow(final Context context) {
+		try {
             context.startActivity(new Intent(Intent.ACTION_VIEW, market.getMarketURI(context)));
-        } catch (ActivityNotFoundException activityNotFoundException1) {
-            Log.e(AppRater.class.getSimpleName(), "Market Intent not found");
-        }
-    }
+		} catch (ActivityNotFoundException activityNotFoundException1) {
+			Log.e(AppRater.class.getSimpleName(), "Market Intent not found");
+		}
+	}
 
-    /**
-     * Set an alternate Market, defaults to Google Play
-     *
-     * @param market
-     */
-    public static void setMarket(Market market) {
-        AppRater.market = market;
-    }
+	/**
+	 * Set an alternate Market, defaults to Google Play
+	 * 
+	 * @param market
+	 */
+	public static void setMarket(Market market) {
+		AppRater.market = market;
+	}
 
-    /**
-     * Get the currently set Market
-     *
-     * @return market
-     */
-    public static Market getMarket() {
-        return market;
-    }
+	/**
+	 * Get the currently set Market
+	 * 
+	 * @return market
+	 */
+	public static Market getMarket() {
+		return market;
+	}
 
-    /**
-     * Sets dialog theme to dark
-     */
-    @TargetApi(11)
-    public static void setDarkTheme() {
-        isDark = true;
-        themeSet = true;
-    }
+	/**
+	 * Sets dialog theme to dark
+	 */
+	@TargetApi(11)
+	public static void setDarkTheme() {
+		isDark = true;
+		themeSet = true;
+	}
 
-    /**
-     * Sets dialog theme to light
-     */
-    @TargetApi(11)
-    public static void setLightTheme() {
-        isDark = false;
-        themeSet = true;
-    }
+	/**
+	 * Sets dialog theme to light
+	 */
+	@TargetApi(11)
+	public static void setLightTheme() {
+		isDark = false;
+		themeSet = true;
+	}
 
-    /**
-     * The meat of the library, actually shows the rate prompt dialog
-     */
-    @SuppressLint("NewApi")
+	/**
+	 * The meat of the library, actually shows the rate prompt dialog
+	 */
+	@SuppressLint("NewApi")
     private static void showRateAlertDialog(final Context context, final SharedPreferences.Editor editor) {
-        Builder builder;
-        if (Build.VERSION.SDK_INT >= 11 && themeSet) {
+		Builder builder;
+		if (Build.VERSION.SDK_INT >= 11 && themeSet) {
             builder = new AlertDialog.Builder(context, (isDark ? AlertDialog.THEME_HOLO_DARK : AlertDialog.THEME_HOLO_LIGHT));
-        } else {
-            builder = new AlertDialog.Builder(context);
-        }
+		} else {
+			builder = new AlertDialog.Builder(context);
+		}
         ApplicationRatingInfo ratingInfo = ApplicationRatingInfo.createApplicationInfo(context);
         builder.setTitle(String.format(context.getString(R.string.dialog_title), ratingInfo.getApplicationName()));
 
-        builder.setMessage(context.getString(R.string.rate_message));
+		builder.setMessage(context.getString(R.string.rate_message));
 
-        builder.setPositiveButton(context.getString(R.string.rate),
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        rateNow(context);
-                        if (editor != null) {
-                            editor.putBoolean(PREF_DONT_SHOW_AGAIN, true);
-                            commitOrApply(editor);
-                        }
-                        dialog.dismiss();
-                    }
-                });
+		builder.setPositiveButton(context.getString(R.string.rate),
+				new DialogInterface.OnClickListener() {
+					public void onClick(DialogInterface dialog, int id) {
+						rateNow(context);
+						if (editor != null) {
+							editor.putBoolean(PREF_DONT_SHOW_AGAIN, true);
+							commitOrApply(editor);
+						}
+						dialog.dismiss();
+					}
+				});
 
-        builder.setNeutralButton(context.getString(R.string.later),
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        if (editor != null) {
-                            Long date_firstLaunch = System.currentTimeMillis();
+		builder.setNeutralButton(context.getString(R.string.later),
+				new DialogInterface.OnClickListener() {
+					public void onClick(DialogInterface dialog, int id) {
+						if (editor != null) {
+							Long date_firstLaunch = System.currentTimeMillis();
                             editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
-                            editor.putLong(PREF_LAUNCH_COUNT, 0);
-                            editor.putBoolean(PREF_REMIND_LATER, true);
-                            editor.putBoolean(PREF_DONT_SHOW_AGAIN, false);
-                            commitOrApply(editor);
-                        }
-                        dialog.dismiss();
-                    }
-                });
-        if (!hideNoButton) {
-            builder.setNegativeButton(context.getString(R.string.no_thanks),
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int id) {
-                            if (editor != null) {
-                                editor.putBoolean(PREF_DONT_SHOW_AGAIN, true);
-                                editor.putBoolean(PREF_REMIND_LATER, false);
+							editor.putLong(PREF_LAUNCH_COUNT, 0);
+							editor.putBoolean(PREF_REMIND_LATER, true);
+							editor.putBoolean(PREF_DONT_SHOW_AGAIN, false);
+							commitOrApply(editor);
+						}
+						dialog.dismiss();
+					}
+				});
+		if (!hideNoButton) {
+			builder.setNegativeButton(context.getString(R.string.no_thanks),
+					new DialogInterface.OnClickListener() {
+						public void onClick(DialogInterface dialog, int id) {
+							if (editor != null) {
+								editor.putBoolean(PREF_DONT_SHOW_AGAIN, true);
+								editor.putBoolean(PREF_REMIND_LATER, false);
                                 long date_firstLaunch = System.currentTimeMillis();
                                 editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
-                                editor.putLong(PREF_LAUNCH_COUNT, 0);
-                                commitOrApply(editor);
-                            }
-                            dialog.dismiss();
-                        }
-                    });
-        }
-        builder.show();
-    }
+								editor.putLong(PREF_LAUNCH_COUNT, 0);
+								commitOrApply(editor);
+							}
+							dialog.dismiss();
+						}
+					});
+		}
+		builder.show();
+	}
 
-    @SuppressLint("NewApi")
-    private static void commitOrApply(SharedPreferences.Editor editor) {
-        if (Build.VERSION.SDK_INT > 8) {
-            editor.apply();
-        } else {
-            editor.commit();
-        }
-    }
+	@SuppressLint("NewApi")
+	private static void commitOrApply(SharedPreferences.Editor editor) {
+		if (Build.VERSION.SDK_INT > 8) {
+			editor.apply();
+		} else {
+			editor.commit();
+		}
+	}
 
-    public static void resetData(Context context) {
+	public static void resetData(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean(PREF_DONT_SHOW_AGAIN, false);
-        editor.putBoolean(PREF_REMIND_LATER, false);
-        editor.putLong(PREF_LAUNCH_COUNT, 0);
-        long date_firstLaunch = System.currentTimeMillis();
-        editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
-        commitOrApply(editor);
-    }
-}
+		SharedPreferences.Editor editor = prefs.edit();
+		editor.putBoolean(PREF_DONT_SHOW_AGAIN, false);
+		editor.putBoolean(PREF_REMIND_LATER, false);
+		editor.putLong(PREF_LAUNCH_COUNT, 0);
+		editor.putLong(PREF_EVENT_COUNT, 0);
+		long date_firstLaunch = System.currentTimeMillis();
+		editor.putLong(PREF_FIRST_LAUNCHED, date_firstLaunch);
+		commitOrApply(editor);
+	}
+}

--- a/AppRaterDemo/src/main/java/org/codechimp/appraterdemo/MainActivity.java
+++ b/AppRaterDemo/src/main/java/org/codechimp/appraterdemo/MainActivity.java
@@ -20,47 +20,60 @@ public class MainActivity extends Activity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_main);		
-		
+		setContentView(R.layout.activity_main);
+
 		buttonTest = (Button) findViewById(R.id.button1);
-		
+
 		buttonTest.setOnClickListener(new OnClickListener() {
 			public void onClick(View v) {
-				
+
 				// This forces display of the rate prompt.
 				// It should only be used for testing purposes
 				AppRater.showRateDialog(v.getContext());
 			}
 		});
 
+		buttonTest = (Button) findViewById(R.id.button2);
+
+		buttonTest.setOnClickListener(new OnClickListener() {
+			public void onClick(View v) {
+
+				// This increments the event count
+				// It should only be used for testing purposes
+				AppRater.incrementEventCount(v.getContext());
+
+				// Check if prompt needs to be shown after this increment.
+				AppRater.app_launched(v.getContext());
+			}
+		});
 
         // Optionally you can set the Market you want to use prior to calling app_launched
-        // If setMarket not called it will default to Google Play
+		// If setMarket not called it will default to Google Play
         // Current implementations are Google Play and Amazon App Store, you can add your own by implementing Market
-        // AppRater.setMarket(new GoogleMarket());
-        // AppRater.setMarket(new AmazonMarket());
+		// AppRater.setMarket(new GoogleMarket());
+		// AppRater.setMarket(new AmazonMarket());
 
         // This will keep a track of when the app was first used and whether to show a prompt
 		// It should be the default implementation of AppRater
-        AppRater.app_launched(this);
+		AppRater.app_launched(this);
 	}
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.activity_main, menu);
-        return super.onCreateOptionsMenu(menu);
-    }
+	@Override
+	public boolean onCreateOptionsMenu(Menu menu) {
+		MenuInflater inflater = getMenuInflater();
+		inflater.inflate(R.menu.activity_main, menu);
+		return super.onCreateOptionsMenu(menu);
+	}
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        super.onOptionsItemSelected(item);
-        switch (item.getItemId()) {
-            case (R.id.menu_ratenow): {
-                AppRater.rateNow(this);
-                return true;
-            }
-        }
-        return false;
-    }
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		super.onOptionsItemSelected(item);
+		switch (item.getItemId()) {
+		case (R.id.menu_ratenow): {
+			AppRater.rateNow(this);
+			return true;
+		}
+		}
+		return false;
+	}
 }

--- a/AppRaterDemo/src/main/res/layout/activity_main.xml
+++ b/AppRaterDemo/src/main/res/layout/activity_main.xml
@@ -20,4 +20,12 @@
         android:layout_below="@id/textview1"
         android:text="@string/force_rate_prompt" />
 
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/button1"
+        android:layout_centerHorizontal="true"
+        android:text="@string/increment_event_count" />
+
 </RelativeLayout>


### PR DESCRIPTION
This PR adds in the support by defining a Event limit. Using this event limit, client application can prompt the user with a rate prompt. This would be useful in cases wherein the the logic to show the prompt is based on usage of application features rather than the launch. 

I have currently set the event limit to 5.
