### PR TITLE
Can now specify custom package name for testing

### DIFF
--- a/AppRater/src/main/java/org/codechimp/apprater/AmazonMarket.java
+++ b/AppRater/src/main/java/org/codechimp/apprater/AmazonMarket.java
@@ -3,12 +3,12 @@ package org.codechimp.apprater;
 import android.content.Context;
 import android.net.Uri;
 
-public class AmazonMarket implements Market {
+public class AmazonMarket extends Market {
     private static String marketLink = "http://www.amazon.com/gp/mas/dl/android?p=";
 
     @Override
     public Uri getMarketURI(Context context) {
-        return Uri.parse(marketLink + context.getPackageName().toString());
+        return Uri.parse(marketLink + Market.getPackageName(context));
     }
 }
 

--- a/AppRater/src/main/java/org/codechimp/apprater/AppRater.java
+++ b/AppRater/src/main/java/org/codechimp/apprater/AppRater.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Log;
-import android.widget.Toast;
 
 public class AppRater {
     // Preference Constants
@@ -33,6 +32,8 @@ public class AppRater {
     private static boolean isVersionNameCheckEnabled;
     private static boolean isVersionCodeCheckEnabled;
     private static boolean isCancelable = true;
+
+    private static String packageName;
 
     private static Market market = new GoogleMarket();
 
@@ -100,8 +101,8 @@ public class AppRater {
      *
      * @param context
      */
-    public static void app_launched(Context context) {
-        app_launched(context, DAYS_UNTIL_PROMPT, LAUNCHES_UNTIL_PROMPT);
+    public static void init(Context context) {
+        init(context, DAYS_UNTIL_PROMPT, LAUNCHES_UNTIL_PROMPT);
     }
 
     /**
@@ -116,10 +117,10 @@ public class AppRater {
      * @param daysForRemind
      * @param launchesForRemind
      */
-    public static void app_launched(Context context, int daysUntilPrompt, int launchesUntilPrompt, int daysForRemind, int launchesForRemind) {
+    public static void init(Context context, int daysUntilPrompt, int launchesUntilPrompt, int daysForRemind, int launchesForRemind) {
         setNumDaysForRemindLater(daysForRemind);
         setNumLaunchesForRemindLater(launchesForRemind);
-        app_launched(context, daysUntilPrompt, launchesUntilPrompt);
+        init(context, daysUntilPrompt, launchesUntilPrompt);
     }
 
     /**
@@ -130,7 +131,7 @@ public class AppRater {
      * @param daysUntilPrompt
      * @param launchesUntilPrompt
      */
-    public static void app_launched(Context context, int daysUntilPrompt, int launchesUntilPrompt) {
+    public static void init(Context context, int daysUntilPrompt, int launchesUntilPrompt) {
         SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         ApplicationRatingInfo ratingInfo = ApplicationRatingInfo.createApplicationInfo(context);
@@ -198,6 +199,10 @@ public class AppRater {
         } catch (ActivityNotFoundException activityNotFoundException1) {
             Log.e(AppRater.class.getSimpleName(), "Market Intent not found");
         }
+    }
+
+    public static void setPackageName(String packageName) {
+        AppRater.market.overridePackageName(packageName);
     }
 
     /**

--- a/AppRater/src/main/java/org/codechimp/apprater/GoogleMarket.java
+++ b/AppRater/src/main/java/org/codechimp/apprater/GoogleMarket.java
@@ -3,11 +3,11 @@ package org.codechimp.apprater;
 import android.content.Context;
 import android.net.Uri;
 
-public class GoogleMarket implements Market {
+public class GoogleMarket extends Market {
     private static String marketLink = "market://details?id=";
 
     @Override
     public Uri getMarketURI(Context context) {
-        return Uri.parse(marketLink + context.getPackageName().toString());
+        return Uri.parse(marketLink + Market.getPackageName(context));
     }
 }

--- a/AppRater/src/main/java/org/codechimp/apprater/Market.java
+++ b/AppRater/src/main/java/org/codechimp/apprater/Market.java
@@ -3,6 +3,20 @@ package org.codechimp.apprater;
 import android.content.Context;
 import android.net.Uri;
 
-public interface Market {
-    public Uri getMarketURI(Context context);
+public abstract class Market {
+
+    protected static String packageName;
+
+    protected abstract Uri getMarketURI(Context context);
+
+    public void overridePackageName(String packageName) {
+        Market.packageName = packageName;
+    }
+
+    protected static String getPackageName(Context context) {
+        if (Market.packageName != null) {
+            return Market.packageName;
+        }
+        return context.getPackageName();
+    }
 }

--- a/AppRaterDemo/src/main/java/org/codechimp/appraterdemo/MainActivity.java
+++ b/AppRaterDemo/src/main/java/org/codechimp/appraterdemo/MainActivity.java
@@ -1,9 +1,6 @@
 package org.codechimp.appraterdemo;
 
-import org.codechimp.apprater.AmazonMarket;
-import org.codechimp.apprater.AppRater;
-import org.codechimp.apprater.GoogleMarket;
-
+import android.app.Activity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -11,7 +8,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
-import android.app.Activity;
+
+import org.codechimp.apprater.AppRater;
 
 public class MainActivity extends Activity {
 
@@ -20,9 +18,10 @@ public class MainActivity extends Activity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_main);		
-		
-		buttonTest = (Button) findViewById(R.id.button1);
+		setContentView(R.layout.activity_main);
+
+
+        buttonTest = (Button) findViewById(R.id.button1);
 		
 		buttonTest.setOnClickListener(new OnClickListener() {
 			public void onClick(View v) {
@@ -34,7 +33,7 @@ public class MainActivity extends Activity {
 		});
 
 
-        // Optionally you can set the Market you want to use prior to calling app_launched
+        // Optionally you can set the Market you want to use prior to calling init
         // If setMarket not called it will default to Google Play
         // Current implementations are Google Play and Amazon App Store, you can add your own by implementing Market
         // AppRater.setMarket(new GoogleMarket());
@@ -42,7 +41,11 @@ public class MainActivity extends Activity {
 
         // This will keep a track of when the app was first used and whether to show a prompt
 		// It should be the default implementation of AppRater
-        AppRater.app_launched(this);
+
+        AppRater.setPackageName("com.johncrossley");
+        AppRater.setNumDaysForRemindLater(7);
+        AppRater.setNumLaunchesForRemindLater(7);
+        AppRater.init(this);
 	}
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=1.0.30
-VERSION_CODE=40
+VERSION_NAME=1.0.29
+VERSION_CODE=39
 GROUP=com.github.codechimp-org.apprater
 
 POM_DESCRIPTION=AppRater Library for Android


### PR DESCRIPTION
When compiling a debug build of your app, it can change the package name which means testers can't properly test this feature. I made a slight modification to allow you to do this.

```
// To change package name, just call...
AppRater.setPackageName("com.custom.package");
```

If no package is set, your default behaviour is used.